### PR TITLE
initialize required passes

### DIFF
--- a/llvm-4.0.0-project/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm-4.0.0-project/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -934,6 +934,9 @@ INITIALIZE_PASS_BEGIN(
     false)
 INITIALIZE_PASS_DEPENDENCY(DominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(TargetLibraryInfoWrapperPass)
+// ASAN-- Helper Wrappers initialize
+INITIALIZE_PASS_DEPENDENCY(PostDominatorTreeWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(AAResultsWrapperPass)
 INITIALIZE_PASS_END(
     AddressSanitizer, "asan",
     "AddressSanitizer: detects use-after-free and out-of-bounds bugs.", false,


### PR DESCRIPTION
We noticed that an error occurs if we build ASAN-- using `-DLLVM_TARGETS_TO_BUILD=AArch64`  option in TAISHAN server with `AArch64`  ISA. Although ASAN-- built without `-DLLVM_TARGETS_TO_BUILD` option works normally, the redundant products of compilation (e.g., the executable codes for other platform but we don't need) will be generate, which occupy more disk space.

First, we use the following script to build ASAN-- without any problem. 

```shell
CC=/usr/bin/clang-4.0 CXX=/usr/bin/clang++-4.0 cmake -DLLVM_ENABLE_PROJECTS="clang;compiler-rt" -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=AArch64 ../llvm
make -j64
```

And then, we compile the example program `test.c` with following command using ASAN--,

``````shell
./bin/clang -fsanitize=address test.c -o test
``````

an error is reported below, Pass '`AddressSanitizerFunctionPass`' is not initialized.

```
Pass 'AddressSanitizerFunctionPass' is not initialized.
Verify if there is a pass dependency cycle.
Required Passes:
        Dominator Tree Construction
        Target Library Information
#0 0x0000000000edd39c llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/home/ASAN--/build/bin/clang-4.0+0xedd39c)
Stack dump:
0.      Program arguments: /home/ASAN--/build/bin/clang-4.0 -cc1 -triple aarch64-unknown-linux-gnu -emit-obj -mrelax-all -disable-free -disable-llvm-verifier -discard-value-names -main-file-name test.c -mrelocation-model static -mthread-model posix -mdisable-fp-elim -fmath-errno -masm-verbose -mconstructor-aliases -munwind-tables -fuse-init-array -target-cpu generic -target-feature +neon -target-abi aapcs -dwarf-column-info -debugger-tuning=gdb -resource-dir /home/ASAN--/build/bin/../lib/clang/4.0.0 -internal-isystem /usr/local/include -internal-isystem /home/ASAN--/build/bin/../lib/clang/4.0.0/include -internal-externc-isystem /usr/include/aarch64-linux-gnu -internal-externc-isystem /include -internal-externc-isystem /usr/include -fdebug-compilation-dir /home/ASAN--/build -ferror-limit 19 -fmessage-length 207 -fsanitize=address -fsanitize-blacklist=/home/ASAN--/build/bin/../lib/clang/4.0.0/asan_blacklist.txt -fno-assume-sane-operator-new -fallow-half-arguments-and-returns -fno-signed-char -fobjc-runtime=gcc -fdiagnostics-show-option -fcolor-diagnostics -o /tmp/test-2f68df.o -x c test.c 
1.      <eof> parser at end of file
clang-4.0: error: unable to execute command: Segmentation fault (core dumped)
clang-4.0: error: clang frontend command failed due to signal (use -v to see invocation)
clang version 4.0.0 (tags/RELEASE_400/final)
Target: aarch64-unknown-linux-gnu
Thread model: posix
InstalledDir: /home/ASAN--/build/./bin
clang-4.0: note: diagnostic msg: PLEASE submit a bug report to http://llvm.org/bugs/ and include the crash backtrace, preprocessed source, and associated run script.
clang-4.0: note: diagnostic msg: 
********************

PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
Preprocessed source(s) and associated run script(s) are located at:
clang-4.0: note: diagnostic msg: /tmp/test-a87660.c
clang-4.0: note: diagnostic msg: /tmp/test-a87660.sh
clang-4.0: note: diagnostic msg: 

********************
```

The reason is that if we build ASAN-- with option "`-DLLVM_TARGETS_TO_BUILD`" (whether `=AArch64` or `=X86`), the two pre-passes (`PostDominatorTreeWrapperPass` and `AAResultsWrapperPass`) added for "Removing Recurring Checks"  will be unavailable.

So we reinitialize the two passes in ASAN-- initialization then the error is fixed. In our test, it works on whether `AArch64`  or `X86` machine. Due to specifying a specific ISA when building ASAN--,  the total product size is reduced from 1.4GB to 0.8GB.